### PR TITLE
Preserve types properly.

### DIFF
--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -4,15 +4,25 @@ import 'dart:math' as math;
 
 part 'main.g.dart';
 
+typedef SomeFunction = int Function(int);
+
 // Only requirement is that it has a constructor with named arguments for all fields
 @FunctionalData()
 class Foo extends $Foo {
   final int number;
   final String name;
+  final SomeFunction function;
+  final int Function(int) inlineFunction;
+  final dynamic_;
 
   String get displayString => "$name[$number]";
 
-  const Foo({this.number, this.name});
+  const Foo(
+      {this.number,
+      this.name,
+      this.function,
+      this.inlineFunction,
+      this.dynamic_});
 }
 
 @FunctionalData()
@@ -40,7 +50,10 @@ class Baz extends $Baz {
 
 main(List<String> arguments) {
   final foo = Foo(number: 42, name: "Marvin");
-  final bar = Bar(foo: foo, foos: [Foo(number: 101, name: "One"), Foo(number: 102, name: "Two")], driver: "One");
+  final bar = Bar(
+      foo: foo,
+      foos: [Foo(number: 101, name: "One"), Foo(number: 102, name: "Two")],
+      driver: "One");
 
   final fooName = Bar$.foo.then(Foo$.name);
   // print(fooName.map((name) => name.toUpperCase(), bar));
@@ -52,12 +65,14 @@ main(List<String> arguments) {
   print(firstFooName.of(bar).update("Twee"));
   // Bar(foo: Foo(number: 42, name: Marvin), foos: [Foo(number: 101, name: Twee), Foo(number: 102, name: Two)], driver: One)
 
-  final nameOfFooNamedTwo = Bar$.foos.then(List$.where<Foo>((foo) => foo.name == "Two")).then(Foo$.name);
+  final nameOfFooNamedTwo = Bar$.foos
+      .then(List$.where<Foo>((foo) => foo.name == "Two"))
+      .then(Foo$.name);
   print(nameOfFooNamedTwo.update(bar, "Due"));
   // Bar(foo: Foo(number: 42, name: Marvin), foos: [Foo(number: 101, name: One), Foo(number: 102, name: Due)], driver: One)
 
-  final driversNumber =
-      Bar$.foos.thenWithContext((bar) => List$.where<Foo>((foo) => foo.name == bar.driver).then(Foo$.number));
+  final driversNumber = Bar$.foos.thenWithContext((bar) =>
+      List$.where<Foo>((foo) => foo.name == bar.driver).then(Foo$.number));
   print(driversNumber.of(bar).value);
   // 101
 }

--- a/example/bin/main.g.dart
+++ b/example/bin/main.g.dart
@@ -9,19 +9,39 @@ part of 'main.dart';
 abstract class $Foo {
   int get number;
   String get name;
+  SomeFunction get function;
+  int Function(int) get inlineFunction;
+  dynamic get dynamic_;
   const $Foo();
-  Foo copyWith({int number, String name}) =>
-      Foo(number: number ?? this.number, name: name ?? this.name);
-  String toString() => "Foo(number: $number, name: $name)";
+  Foo copyWith(
+          {int number,
+          String name,
+          SomeFunction function,
+          int Function(int) inlineFunction,
+          dynamic dynamic_}) =>
+      Foo(
+          number: number ?? this.number,
+          name: name ?? this.name,
+          function: function ?? this.function,
+          inlineFunction: inlineFunction ?? this.inlineFunction,
+          dynamic_: dynamic_ ?? this.dynamic_);
+  String toString() =>
+      "Foo(number: $number, name: $name, function: $function, inlineFunction: $inlineFunction, dynamic_: $dynamic_)";
   bool operator ==(dynamic other) =>
       other.runtimeType == runtimeType &&
       number == other.number &&
-      name == other.name;
+      name == other.name &&
+      function == other.function &&
+      inlineFunction == other.inlineFunction &&
+      dynamic_ == other.dynamic_;
   @override
   int get hashCode {
     var result = 17;
     result = 37 * result + number.hashCode;
     result = 37 * result + name.hashCode;
+    result = 37 * result + function.hashCode;
+    result = 37 * result + inlineFunction.hashCode;
+    result = 37 * result + dynamic_.hashCode;
     return result;
   }
 }
@@ -31,6 +51,13 @@ class Foo$ {
       (s_) => s_.number, (s_, number) => s_.copyWith(number: number));
   static final name =
       Lens<Foo, String>((s_) => s_.name, (s_, name) => s_.copyWith(name: name));
+  static final function = Lens<Foo, SomeFunction>(
+      (s_) => s_.function, (s_, function) => s_.copyWith(function: function));
+  static final inlineFunction = Lens<Foo, int Function(int)>(
+      (s_) => s_.inlineFunction,
+      (s_, inlineFunction) => s_.copyWith(inlineFunction: inlineFunction));
+  static final dynamic_ = Lens<Foo, dynamic>(
+      (s_) => s_.dynamic_, (s_, dynamic_) => s_.copyWith(dynamic_: dynamic_));
 }
 
 abstract class $Bar {
@@ -75,9 +102,9 @@ class Bar$ {
 }
 
 abstract class $Baz {
-  math.Point<num> get prefixedField;
+  math.Point get prefixedField;
   const $Baz();
-  Baz copyWith({math.Point<num> prefixedField}) =>
+  Baz copyWith({math.Point prefixedField}) =>
       Baz(prefixedField: prefixedField ?? this.prefixedField);
   String toString() => "Baz(prefixedField: $prefixedField)";
   bool operator ==(dynamic other) =>
@@ -91,7 +118,6 @@ abstract class $Baz {
 }
 
 class Baz$ {
-  static final prefixedField = Lens<Baz, math.Point<num>>(
-      (s_) => s_.prefixedField,
+  static final prefixedField = Lens<Baz, math.Point>((s_) => s_.prefixedField,
       (s_, prefixedField) => s_.copyWith(prefixedField: prefixedField));
 }


### PR DESCRIPTION
This fixes https://github.com/spkersten/dart_functional_data/issues/3

Instead of "unpacking" function types that usually fallbacks to "dynamic" types, the patch just preserves the full original type.

Example:

typedef SomeFunction = int Function(int);

```
@FunctionalData()
class Foo extends $Foo {
  final int number;
  final String name;
  final SomeFunction function;
  final int Function(int) inlineFunction;
  final dynamic_;

  String get displayString => "$name[$number]";

  const Foo(
      {this.number,
      this.name,
      this.function,
      this.inlineFunction,
      this.dynamic_});
}
```

generates now

```
abstract class $Foo {
  int get number;
  String get name;
  SomeFunction get function;
  int Function(int) get inlineFunction;
  dynamic get dynamic_;
  const $Foo();
  Foo copyWith(
          {int number,
          String name,
          SomeFunction function,
          int Function(int) inlineFunction,
          dynamic dynamic_}) =>
      Foo(
          number: number ?? this.number,
          name: name ?? this.name,
          function: function ?? this.function,
          inlineFunction: inlineFunction ?? this.inlineFunction,
          dynamic_: dynamic_ ?? this.dynamic_);
  String toString() =>
      "Foo(number: $number, name: $name, function: $function, inlineFunction: $inlineFunction, dynamic_: $dynamic_)";
  bool operator ==(dynamic other) =>
      other.runtimeType == runtimeType &&
      number == other.number &&
      name == other.name &&
      function == other.function &&
      inlineFunction == other.inlineFunction &&
      dynamic_ == other.dynamic_;
  @override
  int get hashCode {
    var result = 17;
    result = 37 * result + number.hashCode;
    result = 37 * result + name.hashCode;
    result = 37 * result + function.hashCode;
    result = 37 * result + inlineFunction.hashCode;
    result = 37 * result + dynamic_.hashCode;
    return result;
  }
}
```
