### PR TITLE
Upgrade dependencies null safety and remove plain optional

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,13 +2,13 @@ name: example
 description: example of functional data
 
 environment:
-  sdk: '>=2.12.0-29.10.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   functional_data:
 
 dev_dependencies:
-  build_runner: ^1.10.0
-  build_resolvers: ">=1.3.10"
+  build_runner: ^1.12.1
+  build_resolvers: ">=2.0.0"
   functional_data_generator:
     path: ../functional_data_generator

--- a/functional_data/lib/src/lenses.dart
+++ b/functional_data/lib/src/lenses.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:meta/meta.dart';
-import 'package:plain_optional/plain_optional.dart';
 
 /// Get the value of a field of type [T] of [subject]
 typedef Getter<S, T> = T Function(S subject);
@@ -113,8 +112,8 @@ class List$ {
         },
       );
 
-  static Lens<List<T>, Optional<T>> whereOptional<T>(bool Function(T) predicate) => Lens<List<T>, Optional<T>>(
-        (s) => Optional<T>(s.firstWhereOrNull(predicate)),
+  static Lens<List<T>, T?> whereOptional<T>(bool Function(T) predicate) => Lens<List<T>, T?>(
+        (s) => s.firstWhereOrNull(predicate),
         (s, t) {
           if (!t.hasValue) return s;
           final index = s.indexWhere(predicate);
@@ -122,6 +121,6 @@ class List$ {
           final newS = List<T>.from(s);
           newS.replaceRange(index, index + 1, [t.unsafe]);
           return newS;
-        } as List<T> Function(List<T>, Optional<T>),
+        } as List<T> Function(List<T>, T?),
       );
 }

--- a/functional_data/pubspec.yaml
+++ b/functional_data/pubspec.yaml
@@ -5,9 +5,8 @@ description: >-
 homepage: https://github.com/spkersten/dart_functional_data
 
 environment:
-  sdk: '>=2.12.0-29.10.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  meta: ^1.3.0-nullsafety.6
-  collection: ^1.15.0-nullsafety.5
-  plain_optional: ^1.0.0-nullsafety.0
+  meta: ^1.3.0
+  collection: ^1.15.0

--- a/functional_data_generator/pubspec.yaml
+++ b/functional_data_generator/pubspec.yaml
@@ -5,15 +5,15 @@ description: >-
 homepage: https://github.com/spkersten/dart_functional_data
 
 environment:
-  sdk: '>=2.12.0-29.10.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.40.6
-  build: ^1.5.0
-  source_gen: ^0.9.6
-  collection: ^1.15.0-nullsafety.5
+  analyzer: ^1.1.0
+  build: ^2.0.0
+  source_gen: ^0.9.10+4
+  collection: ^1.15.0
   functional_data: ^1.0.0-nullsafety.0
 
 dev_dependencies:
-  build_runner: ^1.10.0
-  build_resolvers: ">=1.4.0"
+  build_runner: ^1.12.1
+  build_resolvers: "^2.0.0"


### PR DESCRIPTION
Plain optional is not needed.

Is it also possible to publish based on this a stable 1.0 version? Reason I ask is that I cannot publish a stable 3.0 version of reactive ble since I depend on a pre-release of functional data. 