### PR TITLE
make functional data compliant with latest build runner and flutter 2.2

### DIFF
--- a/example/bin/main.g.dart
+++ b/example/bin/main.g.dart
@@ -6,10 +6,6 @@ part of 'main.dart';
 // FunctionalDataGenerator
 // **************************************************************************
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $Foo {
   const $Foo();
   int get number;
@@ -47,10 +43,6 @@ class Foo$ {
       (s_) => s_.enu, (s_, enu) => s_.copyWith(enu: enu));
 }
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $Bar {
   const $Bar();
   Foo get foo;
@@ -96,10 +88,6 @@ class Bar$ {
       (s_) => s_.cache, (s_, cache) => s_.copyWith(cache: cache));
 }
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $Baz {
   const $Baz();
   math.Point get prefixedField;

--- a/functional_data_generator/pubspec.yaml
+++ b/functional_data_generator/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.1.0
-  build: ^2.0.0
-  source_gen: ^0.9.10+4
+  analyzer: ^1.5.0
+  build: ^2.0.1
+  source_gen: ^1.0.0
   collection: ^1.15.0
   functional_data: ^1.0.0
 
 dev_dependencies:
-  build_runner: ^1.12.1
-  build_resolvers: "^2.0.0"
+  build_runner: ^2.0.3
+  build_resolvers: "^2.0.2"


### PR DESCRIPTION
We would like to upgrade some outdated dependencies on reactive ble but we cannot do this since functional data still relies on an older version of build_runner. This pr fixes it