### PR TITLE
Updates to analyzer ^7.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 build/
 
 pubspec_overrides.yaml
+
+# ASDF
+.tool-versions

--- a/functional_data_generator/pubspec.yaml
+++ b/functional_data_generator/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  analyzer: '>=2.0.0 <7.0.0'
-  build: ^2.0.1
+  analyzer: '^7.4.0'
+  build: ^3.0.0
   collection: ^1.15.0
   functional_data: ^1.1.1
-  source_gen: ^1.2.7
+  source_gen: ^3.1.0
   yaml: ^3.1.2
 
 dev_dependencies:
-  build_resolvers: "^2.0.2"
+  build_resolvers: "^3.0.2"
   build_runner: ^2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: functional_data_workspace
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 dev_dependencies:
-  melos: ^5.3.0
+  melos: ^6.3.0


### PR DESCRIPTION
- Analyzer 6 depends on _macros which was removed from latest dart (3.9.0) of flutter stable So support to analyzer 7 onwards is needed to be able to update to latest flutter
- Also drops supports to all other versions prior to 7 since none of them compiles with current code (analyzer has a very unstable interface)